### PR TITLE
Switch to the Grafana "standard" key name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.0
+
+- support for Grafana provisioning configuration
+
 ## 1.0.2
 
 - update plugin's description and bump toolkit version

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "golioth-websocket",
-  "version": "1.0.2",
-  "description": "",
+  "version": "1.1.0",
+  "description": "A Web Socket Data Source Plugin for Grafana",
   "scripts": {
     "start": "yarn watch",
     "build": "grafana-toolkit plugin:build",
@@ -12,6 +12,11 @@
     "sign": "grafana-toolkit plugin:sign"
   },
   "author": "Golioth",
+  "contributors": [
+    {
+      "name": "@mountainash"
+    }
+  ],
   "license": "Apache-2.0",
   "dependencies": {
     "@grafana/data": "latest",

--- a/pkg/plugin/ws_data_proxy.go
+++ b/pkg/plugin/ws_data_proxy.go
@@ -103,7 +103,7 @@ func (wsdp *wsDataProxy) encodeURL(req *backend.RunStreamRequest) (string, error
 		return "", fmt.Errorf("failed to read JSON Data Source Instance Settings: %s", err.Error())
 	}
 
-	host := reqJsonData["host"].(string)
+	host := reqJsonData["url"].(string)
 
 	wsUrl, err := url.Parse(host)
 	if err != nil {

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -14,7 +14,7 @@ export const ConfigEditor: FC<Props> = ({ options, onOptionsChange }) => {
   const onHostChange = (event: ChangeEvent<HTMLInputElement>) => {
     const jsonData = {
       ...options.jsonData,
-      host: event.target.value,
+      url: event.target.value,
     }
     onOptionsChange({ ...options, jsonData })
   }
@@ -29,7 +29,7 @@ export const ConfigEditor: FC<Props> = ({ options, onOptionsChange }) => {
             labelWidth={10}
             inputWidth={30}
             onChange={onHostChange}
-            value={jsonData.host || ''}
+            value={jsonData.url || ''}
             placeholder='wss://api.domain.io/v1/ws/'
           />
         </div>

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -42,7 +42,7 @@
         "path": "img/assets/grafana-websockets-plugin-streaming.png"
       }
     ],
-    "version": "1.0.2",
+    "version": "1.1.0",
     "updated": "%TODAY%"
   },
   "dependencies": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,7 @@ export const defaultQuery: Partial<Query> = {
 }
 
 export interface DataSourceOptions extends DataSourceJsonData {
-  host?: string
+  url?: string
 }
 
 export interface SecureJsonData {


### PR DESCRIPTION
Closes #22

Allows the "top-level" use of the _standard_ configuration key `url:`